### PR TITLE
fix: Add try-catch blocks for JSON.parse in UploadPage

### DIFF
--- a/src/components/UploadPage.tsx
+++ b/src/components/UploadPage.tsx
@@ -1,14 +1,14 @@
-import React, { useState, useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
-import { Loader2, Shield, Clock, Eye, Zap, FileText, Link, Type as TypeIcon } from "lucide-react";
+import axios, { AxiosError } from "axios";
+import { Clock, Eye, FileText, Link, Loader2, Shield, Type as TypeIcon, Zap } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import FileUpload from "./FileUpload";
+import { Button } from "./ui/button";
+import { Checkbox } from "./ui/checkbox";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
-import { Checkbox } from "./ui/checkbox";
-import { Button } from "./ui/button";
-import { toast } from "sonner";
-import axios, { AxiosError } from "axios";
 import { Switch } from "./ui/switch";
-import FileUpload from "./FileUpload";
 
 type FileType =
   | "image"
@@ -105,12 +105,20 @@ export default function UploadPage() {
   const [passwordProtect, setPasswordProtect] = useState(false);
   const [password, setPassword] = useState("");
   const [selfDestruct, setSelfDestruct] = useState(false);
-  const [destructViews, setDestructViews] = useState(() =>
-    JSON.parse(sessionStorage.getItem("destructViews") || "false")
-  );
-  const [destructTime, setDestructTime] = useState(() =>
-    JSON.parse(sessionStorage.getItem("destructTime") || "false")
-  );
+  const [destructViews, setDestructViews] = useState(() => {
+    try {
+      return JSON.parse(sessionStorage.getItem("destructViews") || "false");
+    } catch {
+      return false;
+    }
+  });
+  const [destructTime, setDestructTime] = useState(() => {
+    try {
+      return JSON.parse(sessionStorage.getItem("destructTime") || "false");
+    } catch {
+      return false;
+    }
+  });
   const [viewsValue, setViewsValue] = useState(
     () => sessionStorage.getItem("viewsValue") || ""
   );
@@ -123,12 +131,22 @@ export default function UploadPage() {
   const [textValue, setTextValue] = useState("");
   const [compressPdf, setCompressPdf] = useState(false);
   const [lastQR, setLastQR] = useState(() => {
-    const data = sessionStorage.getItem("lastQR");
-    return data ? JSON.parse(data) : null;
+    try {
+      const data = sessionStorage.getItem("lastQR");
+      return data ? JSON.parse(data) : null;
+    } catch {
+      sessionStorage.removeItem("lastQR");
+      return null;
+    }
   });
   const [lastQRFormHash, setLastQRFormHash] = useState(() => {
-    const data = sessionStorage.getItem("lastQRFormHash");
-    return data || null;
+    try {
+      const data = sessionStorage.getItem("lastQRFormHash");
+      return data || null;
+    } catch {
+      sessionStorage.removeItem("lastQRFormHash");
+      return null;
+    }
   });
 
   // Persist state to sessionStorage
@@ -565,7 +583,7 @@ export default function UploadPage() {
               placeholder="Enter a memorable name..."
               value={qrName}
               onChange={handleQrNameChange}
-              className="input-focus text-base rounded-xl border-border bg-background h-14 px-6 font-medium text-lg focus-ring"
+              className="input-focus rounded-xl border-border bg-background h-14 px-6 font-medium text-lg focus-ring"
             />
           </div>
 
@@ -586,7 +604,7 @@ export default function UploadPage() {
                 value={urlValue}
                 onChange={(e) => setUrlValue(e.target.value)}
                 placeholder="https://example.com"
-                className="input-focus text-base rounded-xl border-border bg-background h-14 px-6 text-lg focus-ring"
+                className="input-focus rounded-xl border-border bg-background h-14 px-6 text-lg focus-ring"
               />
               <p className="text-sm text-muted-foreground pl-6">
                 {TYPE_MESSAGES[type]}
@@ -721,7 +739,7 @@ export default function UploadPage() {
                     <Checkbox
                       id="destruct-views"
                       checked={destructViews}
-                      onCheckedChange={(checked) =>
+                      onCheckedChange={(checked: boolean | "indeterminate") =>
                         setDestructViews(checked === true)
                       }
                       className="data-[state=checked]:bg-orange-500 data-[state=checked]:border-orange-500 w-5 h-5"
@@ -751,7 +769,7 @@ export default function UploadPage() {
                     <Checkbox
                       id="destruct-time"
                       checked={destructTime}
-                      onCheckedChange={(checked) =>
+                      onCheckedChange={(checked: boolean | "indeterminate") =>
                         setDestructTime(checked === true)
                       }
                       className="data-[state=checked]:bg-orange-500 data-[state=checked]:border-orange-500 w-5 h-5"


### PR DESCRIPTION

## Team 065

## Issue
Fixes #49 

## Description
Fixed uncaught JSON.parse errors in UploadPage component that caused the application to crash when sessionStorage contained corrupted JSON data.

## Changes Made
- Added try-catch blocks around all JSON.parse() calls in UploadPage.tsx (lines 109-122, 133-147)
- Implemented automatic cleanup of corrupted sessionStorage entries on parse failure
- Return safe default values (false for booleans, null for objects) when parsing fails
- Fixed React 19+ compatibility by removing React default import
- Removed duplicate CSS classes (text-base conflicting with text-lg)
- Added proper TypeScript type annotations for checkbox onCheckedChange handlers



## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing Done
- ✅ All TypeScript compilation errors resolved
- ✅ No ESLint warnings or errors
- ✅ JSON.parse calls properly wrapped in try-catch blocks
- ✅ Corrupted sessionStorage data handled gracefully
- ✅ Application loads without crashes when storage is corrupted

## Files Changed
- `src/components/UploadPage.tsx`

## Screenshots
[Optional: Add before/after screenshots if applicable]