### PR TITLE
fix: Add try-catch block for JSON.parse in localStorage handling

### DIFF
--- a/src/components/UploadPage.tsx
+++ b/src/components/UploadPage.tsx
@@ -581,21 +581,26 @@ export default function UploadPage() {
     // check for last zap in local storage
     const lastZapStr = localStorage.getItem("lastZap");
     if (lastZapStr) {
-      const lastQR = JSON.parse(lastZapStr);
-      // Only restore if current state is empty
-      // We check the refs or assume it's mount time
-      setQrName(lastQR.name || "");
-      setPasswordProtect(!!lastQR.password);
-      setPassword(lastQR.password || "");
-      setSelfDestruct(!!lastQR.selfDestruct);
-      setDestructViews(!!lastQR.viewLimit);
-      setDestructTime(!!lastQR.expiresAt);
-      setViewsValue(lastQR.viewLimit ? String(lastQR.viewLimit) : "");
-      setTimeValue(lastQR.expiresAt ? String(lastQR.expiresAt) : "");
-      setUrlValue(lastQR.originalUrl || "");
-      setTextValue(lastQR.textContent || "");
-      setType(lastQR.type ? lastQR.type.toLowerCase() : "file");
-      // Note: File cannot be restored for security reasons
+      try {
+        const lastQR = JSON.parse(lastZapStr);
+        // Only restore if current state is empty
+        // We check the refs or assume it's mount time
+        setQrName(lastQR.name || "");
+        setPasswordProtect(!!lastQR.password);
+        setPassword(lastQR.password || "");
+        setSelfDestruct(!!lastQR.selfDestruct);
+        setDestructViews(!!lastQR.viewLimit);
+        setDestructTime(!!lastQR.expiresAt);
+        setViewsValue(lastQR.viewLimit ? String(lastQR.viewLimit) : "");
+        setTimeValue(lastQR.expiresAt ? String(lastQR.expiresAt) : "");
+        setUrlValue(lastQR.originalUrl || "");
+        setTextValue(lastQR.textContent || "");
+        setType(lastQR.type ? lastQR.type.toLowerCase() : "file");
+        // Note: File cannot be restored for security reasons
+      } catch (error) {
+        console.warn("Failed to parse lastZap from localStorage:", error);
+        localStorage.removeItem("lastZap");
+      }
     }
   }, []); // Run only once on mount to restore previous session state
 


### PR DESCRIPTION
### Description
Fixed a critical bug where the UploadPage component would crash when `sessionStorage` or `localStorage` contained corrupted JSON data. The app was calling `JSON.parse()` without proper error handling, causing uncaught exceptions that would break the entire page.

### Team Information
Team Number : Team 065

### Issue
closes #49

### Changes Made
- Added try-catch block around `JSON.parse()` call in the useEffect hook (line 584) that reads from `localStorage`
- Implemented automatic cleanup of corrupted data by removing invalid entries from storage
- Added console warnings to help debug storage issues without breaking the user experience
- Note: State initialization already had proper try-catch blocks for `destructViews`, `destructTime`, and `lastQR`

### Files Changed
- `src/components/UploadPage.tsx`

### Testing Steps to Reproduce Original Bug
1. Open browser DevTools
2. Go to Application → Storage → Session Storage (or Local Storage)
3. Manually corrupt the `lastQR` or `lastZap` value with invalid JSON
4. Refresh the page
5. **Before fix:** Page crashes with JSON.parse error
6. **After fix:** Page loads normally, warning logged to console, corrupted data removed

### Technical Details
The fix wraps the vulnerable `JSON.parse(lastZapStr)` call in a try-catch block that:
- Catches parsing errors gracefully
- Logs a warning to the console for debugging
- Removes the corrupted entry from storage
- Prevents the exception from propagating and crashing the app

### Impact
- Improved app stability and reliability
- Better user experience when storage data gets corrupted
- No breaking changes to existing functionality